### PR TITLE
💄 Improve be_groups editing warning message

### DIFF
--- a/Classes/Model/BeGroup.php
+++ b/Classes/Model/BeGroup.php
@@ -29,6 +29,7 @@ use SebastianHofer\BePermissions\Collection\BeGroupFieldCollection;
 use SebastianHofer\BePermissions\Configuration\BeGroupConfiguration;
 use SebastianHofer\BePermissions\Value\BeGroupFieldInterface;
 use SebastianHofer\BePermissions\Value\CodeManagedGroup;
+use SebastianHofer\BePermissions\Value\DeployProcessing;
 use SebastianHofer\BePermissions\Value\Identifier;
 
 final class BeGroup implements JsonSerializable
@@ -149,5 +150,31 @@ final class BeGroup implements JsonSerializable
         }
 
         return $isCodeManaged;
+    }
+
+    public function deployProcessingIsOverrule(): bool
+    {
+        $isOverrule = false;
+
+        foreach ($this->beGroupFieldCollection as $beGroupField) {
+            if ($beGroupField instanceof DeployProcessing) {
+                $isOverrule = $beGroupField->isOverrule();
+            }
+        }
+
+        return $isOverrule;
+    }
+
+    public function deployProcessingIsExtend(): bool
+    {
+        $isExtend = false;
+
+        foreach ($this->beGroupFieldCollection as $beGroupField) {
+            if ($beGroupField instanceof DeployProcessing) {
+                $isExtend = $beGroupField->isExtend();
+            }
+        }
+
+        return $isExtend;
     }
 }

--- a/Classes/Value/DeployProcessing.php
+++ b/Classes/Value/DeployProcessing.php
@@ -37,6 +37,16 @@ final class DeployProcessing extends AbstractStringField
 
     private string $fieldName = 'deploy_processing';
 
+    public static function createOverrule(): DeployProcessing
+    {
+        return new self(self::OVERRULE);
+    }
+
+    public static function createExtend(): DeployProcessing
+    {
+        return new self(self::EXTEND);
+    }
+
     public static function createFromDBValue(string $dbValue): DeployProcessing
     {
         if (empty($dbValue)) {

--- a/Configuration/TCA/Overrides/be_groups.php
+++ b/Configuration/TCA/Overrides/be_groups.php
@@ -58,4 +58,39 @@ call_user_func(function () {
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('be_groups', $fields);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('be_groups', 'identifier,code_managed_group,deploy_processing', '', 'after:title');
+
+    if (
+        isset($GLOBALS['TCA']['be_groups']['columns'])
+        && is_array($GLOBALS['TCA']['be_groups']['columns'])
+        && \TYPO3\CMS\Core\Core\Environment::getContext()->isProduction()
+    ) {
+        $displayCond = [
+            'OR' => [
+                'FIELD:code_managed_group:REQ:false',
+                'FIELD:deploy_processing:!=:' . (string)\SebastianHofer\BePermissions\Value\DeployProcessing::createOverrule()
+            ]
+        ];
+
+        $fieldsToShowReadonly = [
+            'identifier',
+            'code_managed_group',
+            'deploy_processing'
+        ];
+
+        $fieldsToIgnore = [
+            'title'
+        ];
+
+        foreach ($GLOBALS['TCA']['be_groups']['columns'] as $column => $config) {
+            if (in_array($column, $fieldsToIgnore)) {
+                continue;
+            }
+
+            if (in_array($column, $fieldsToShowReadonly)) {
+                $GLOBALS['TCA']['be_groups']['columns'][$column]['config']['readOnly'] = true;
+            } else {
+                $GLOBALS['TCA']['be_groups']['columns'][$column]['displayCond'] = $displayCond;
+            }
+        }
+    }
 });

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages">
+		<body>
+			<trans-unit id="edit_warning.extend.header">
+				<source>Edit Warning</source>
+			</trans-unit>
+			<trans-unit id="edit_warning.extend.text">
+				<source>You are about to edit a code managed group! Proceed only if you are absolutely sure what you are doing.</source>
+			</trans-unit>
+			<trans-unit id="edit_warning.overrule.header">
+				<source>Edit Warning</source>
+			</trans-unit>
+			<trans-unit id="edit_warning.overrule.text">
+				<source>You can not edit this group, because it is code managed and changes would be overruled with the next deployment.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Tests/Unit/Model/BeGroupTest.php
+++ b/Tests/Unit/Model/BeGroupTest.php
@@ -28,6 +28,7 @@ use SebastianHofer\BePermissions\Collection\BeGroupFieldCollection;
 use SebastianHofer\BePermissions\Configuration\BeGroupConfiguration;
 use SebastianHofer\BePermissions\Value\AllowedLanguages;
 use SebastianHofer\BePermissions\Value\CodeManagedGroup;
+use SebastianHofer\BePermissions\Value\DeployProcessing;
 use SebastianHofer\BePermissions\Value\ExplicitAllowDeny;
 use SebastianHofer\BePermissions\Value\Identifier;
 use SebastianHofer\BePermissions\Model\BeGroup;
@@ -380,6 +381,51 @@ final class BeGroupTest extends UnitTestCase
         $group = $this->createTestGroup();
 
         $this->assertFalse($group->isCodeManaged());
+    }
+
+    /**
+     * @test
+     */
+    public function knows_its_deploy_processing_overrule(): void //phpcs:ignore
+    {
+        $fieldCollection = new BeGroupFieldCollection();
+
+        $deployProcessing = DeployProcessing::createOverrule();
+        $fieldCollection->add($deployProcessing);
+
+        $group = new BeGroup(new Identifier('tmp'), $fieldCollection);
+
+        $this->assertTrue($group->deployProcessingIsOverrule());
+        $this->assertFalse($group->deployProcessingIsExtend());
+    }
+
+    /**
+     * @test
+     */
+    public function knows_its_deploy_processing_extend(): void //phpcs:ignore
+    {
+        $fieldCollection = new BeGroupFieldCollection();
+
+        $deployProcessing = DeployProcessing::createExtend();
+        $fieldCollection->add($deployProcessing);
+
+        $group = new BeGroup(new Identifier('tmp'), $fieldCollection);
+
+        $this->assertTrue($group->deployProcessingIsExtend());
+        $this->assertFalse($group->deployProcessingIsOverrule());
+    }
+
+    /**
+     * @test
+     */
+    public function fall_back_is_false_for_deploy_processing(): void //phpcs:ignore
+    {
+        $fieldCollection = new BeGroupFieldCollection();
+
+        $group = new BeGroup(new Identifier('tmp'), $fieldCollection);
+
+        $this->assertFalse($group->deployProcessingIsOverrule());
+        $this->assertFalse($group->deployProcessingIsExtend());
     }
 
     private function createTestGroup(): BeGroup


### PR DESCRIPTION
* Differ between extend and overrule with the message.
* Make overrule groups not editable anymore.

Resolves #46