### PR TITLE
🐛 Fix failure of deploy command with missing subgroup records

### DIFF
--- a/Classes/Model/BeGroup.php
+++ b/Classes/Model/BeGroup.php
@@ -31,6 +31,7 @@ use SebastianHofer\BePermissions\Value\BeGroupFieldInterface;
 use SebastianHofer\BePermissions\Value\CodeManagedGroup;
 use SebastianHofer\BePermissions\Value\DeployProcessing;
 use SebastianHofer\BePermissions\Value\Identifier;
+use SebastianHofer\BePermissions\Value\SubGroup;
 
 final class BeGroup implements JsonSerializable
 {
@@ -176,5 +177,16 @@ final class BeGroup implements JsonSerializable
         }
 
         return $isExtend;
+    }
+
+    public function getSubGroup(): ?SubGroup
+    {
+        foreach ($this->beGroupFieldCollection as $beGroupField) {
+            if ($beGroupField instanceof SubGroup) {
+                return $beGroupField;
+            }
+        }
+
+        return null;
     }
 }

--- a/Tests/Functional/Repoitory/Fixtures/missing_subgroups_will_be_created_as_dummy_group_non_code_managed/be_groups.xml
+++ b/Tests/Functional/Repoitory/Fixtures/missing_subgroups_will_be_created_as_dummy_group_non_code_managed/be_groups.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<dataset>
+    <be_groups>
+        <uid>1</uid>
+        <identifier>test-group-a</identifier>
+        <title>Some group title A</title>
+        <non_exclude_fields>pages:title,pages:hidden,tt_content:title</non_exclude_fields>
+    </be_groups>
+    <be_groups>
+        <uid>2</uid>
+        <identifier>test-group-b</identifier>
+        <title>Some group title B</title>
+        <non_exclude_fields>pages:title,pages:hidden,tt_content:hidden</non_exclude_fields>
+    </be_groups>
+    <be_groups>
+        <uid>3</uid>
+        <identifier>test-group-c</identifier>
+        <title>Some group title C</title>
+        <non_exclude_fields>pages:title,pages:hidden,tt_content:bodytext</non_exclude_fields>
+    </be_groups>
+</dataset>

--- a/Tests/Functional/Repoitory/Fixtures/missing_subgroups_will_be_created_as_dummy_group_non_code_managed/expected_groups.php
+++ b/Tests/Functional/Repoitory/Fixtures/missing_subgroups_will_be_created_as_dummy_group_non_code_managed/expected_groups.php
@@ -1,0 +1,44 @@
+<?php
+
+return array (
+  0 =>
+  array (
+    'uid' => 1,
+    'identifier' => 'test-group-a',
+    'title' => 'Some group title A',
+    'code_managed_group' => 0,
+    'subgroup' => null,
+  ),
+  1 =>
+  array (
+    'uid' => 2,
+    'identifier' => 'test-group-b',
+    'title' => 'Some group title B',
+    'code_managed_group' => 0,
+    'subgroup' => null,
+  ),
+  2 =>
+  array (
+    'uid' => 3,
+    'identifier' => 'test-group-c',
+    'title' => 'Some group title C',
+    'code_managed_group' => 0,
+    'subgroup' => null,
+  ),
+  3 =>
+  array (
+    'uid' => 4,
+    'identifier' => 'new_group_with_subgroups',
+    'title' => 'new group with subgroups',
+    'code_managed_group' => 0,
+    'subgroup' => '3,5',
+  ),
+  4 =>
+  array (
+    'uid' => 5,
+    'identifier' => 'test-group-d',
+    'title' => 'test-group-d',
+    'code_managed_group' => 1,
+    'subgroup' => null,
+  ),
+);

--- a/Tests/Unit/Model/BeGroupTest.php
+++ b/Tests/Unit/Model/BeGroupTest.php
@@ -33,6 +33,7 @@ use SebastianHofer\BePermissions\Value\ExplicitAllowDeny;
 use SebastianHofer\BePermissions\Value\Identifier;
 use SebastianHofer\BePermissions\Model\BeGroup;
 use SebastianHofer\BePermissions\Value\NonExcludeFields;
+use SebastianHofer\BePermissions\Value\SubGroup;
 use SebastianHofer\BePermissions\Value\Title;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -426,6 +427,23 @@ final class BeGroupTest extends UnitTestCase
 
         $this->assertFalse($group->deployProcessingIsOverrule());
         $this->assertFalse($group->deployProcessingIsExtend());
+    }
+
+    /**
+     * @test
+     */
+    public function get_subgroup_field(): void //phpcs:ignore
+    {
+        $title = Title::createFromYamlConfiguration('new group with subgroups');
+        $identifier = Identifier::buildNewFromTitle((string)$title);
+        $subGroupField = SubGroup::createFromYamlConfiguration(['test-group-c', 'test-group-d']);
+        $fieldCollection = new BeGroupFieldCollection();
+        $fieldCollection->add($subGroupField);
+        $fieldCollection->add($title);
+
+        $group = new BeGroup($identifier, $fieldCollection);
+
+        $this->assertSame($subGroupField, $group->getSubGroup());
     }
 
     private function createTestGroup(): BeGroup


### PR DESCRIPTION
Create dummy records in this case. Those records will be connected
to the real records once they are present in yaml files.