### PR TITLE
🐛 Fix failing identifier creation for new be_groups on production

### DIFF
--- a/Configuration/TCA/Overrides/be_groups.php
+++ b/Configuration/TCA/Overrides/be_groups.php
@@ -72,7 +72,6 @@ call_user_func(function () {
         ];
 
         $fieldsToShowReadonly = [
-            'identifier',
             'code_managed_group',
             'deploy_processing'
         ];


### PR DESCRIPTION
If the field is readonly in TCA it is not sent in fieldArray anymore. So we need to keep it just not editable as before also on production.